### PR TITLE
Add TFRecord support and transformation job

### DIFF
--- a/easy-batch-core/pom.xml
+++ b/easy-batch-core/pom.xml
@@ -58,6 +58,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.tensorflow</groupId>
+            <artifactId>tensorflow-core-api</artifactId>
+            <version>0.4.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/easy-batch-core/src/main/java/org/jeasy/batch/core/writer/TFRecordRecordWriter.java
+++ b/easy-batch-core/src/main/java/org/jeasy/batch/core/writer/TFRecordRecordWriter.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ *  Copyright (c) 2021, Mahmoud Ben Hassine
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.jeasy.batch.core.writer;
+
+import org.jeasy.batch.core.record.Batch;
+import org.jeasy.batch.core.record.Record;
+import org.tensorflow.example.TFRecordWriter;
+
+import java.nio.file.Path;
+
+/**
+ * A writer that writes byte array records into TFRecord files.
+ */
+public class TFRecordRecordWriter implements RecordWriter<byte[]> {
+
+    private final Path path;
+    private TFRecordWriter writer;
+
+    /**
+     * Create a new {@link TFRecordRecordWriter}.
+     *
+     * @param path output file path
+     */
+    public TFRecordRecordWriter(Path path) {
+        this.path = path;
+    }
+
+    @Override
+    public void open() throws Exception {
+        writer = new TFRecordWriter(path.toString());
+    }
+
+    @Override
+    public void writeRecords(Batch<byte[]> batch) throws Exception {
+        for (Record<byte[]> record : batch) {
+            writer.write(record.getPayload());
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (writer != null) {
+            writer.close();
+        }
+    }
+}

--- a/easy-batch-core/src/test/java/org/jeasy/batch/core/writer/TFRecordRecordWriterTest.java
+++ b/easy-batch-core/src/test/java/org/jeasy/batch/core/writer/TFRecordRecordWriterTest.java
@@ -1,0 +1,53 @@
+package org.jeasy.batch.core.writer;
+
+import org.jeasy.batch.core.record.Batch;
+import org.jeasy.batch.core.record.Header;
+import org.jeasy.batch.core.record.Record;
+import org.jeasy.batch.core.record.GenericRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link TFRecordRecordWriter}. */
+@RunWith(MockitoJUnitRunner.class)
+public class TFRecordRecordWriterTest {
+
+    private final Path path = Paths.get("target/test.tfrecord");
+
+    @Mock
+    private Header header;
+
+    private Record<byte[]> record1, record2;
+    private TFRecordRecordWriter writer;
+
+    @Before
+    public void setUp() throws Exception {
+        Files.deleteIfExists(path);
+        record1 = new GenericRecord<>(header, "foo".getBytes());
+        record2 = new GenericRecord<>(header, "bar".getBytes());
+        writer = new TFRecordRecordWriter(path);
+        writer.open();
+    }
+
+    @Test
+    public void testWrite() throws Exception {
+        writer.writeRecords(new Batch<>(record1, record2));
+        writer.close();
+        assertThat(Files.exists(path)).isTrue();
+        assertThat(Files.size(path)).isGreaterThan(0);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Files.deleteIfExists(path);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <module>easy-batch-archetype</module>
         <module>easy-batch-test-common</module>
         <module>easy-batch-tutorials</module>
+        <module>transformations</module>
     </modules>
 
     <developers>

--- a/transformations/README.md
+++ b/transformations/README.md
@@ -1,0 +1,9 @@
+# Transformations
+
+This module provides a batch job to convert impression JSONL files into TFRecord files.
+
+```
+java -jar transformations.jar <inputPath> <outputPath> <startDate> <endDate>
+```
+
+Dates must be in `YYYY-MM-DD` format. Output files mirror the partition layout of the input tree with `.tfrecord` suffix.

--- a/transformations/pom.xml
+++ b/transformations/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jeasy</groupId>
+        <artifactId>easy-batch</artifactId>
+        <version>7.0.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>transformations</artifactId>
+    <version>7.0.3-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jeasy</groupId>
+            <artifactId>easy-batch-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jeasy</groupId>
+            <artifactId>easy-batch-flatfile</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jeasy</groupId>
+            <artifactId>easy-batch-jackson</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.tensorflow</groupId>
+            <artifactId>tensorflow-core-api</artifactId>
+            <version>0.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/transformations/src/main/java/transform/Action.java
+++ b/transformations/src/main/java/transform/Action.java
@@ -1,0 +1,7 @@
+package transform;
+
+/** Customer action on an item. */
+public class Action {
+    public Item item;
+    public String occurred_at;
+}

--- a/transformations/src/main/java/transform/Impression.java
+++ b/transformations/src/main/java/transform/Impression.java
@@ -1,0 +1,7 @@
+package transform;
+
+/** Single item impression. */
+public class Impression {
+    public Item item;
+    public boolean is_order;
+}

--- a/transformations/src/main/java/transform/ImpressionProcessor.java
+++ b/transformations/src/main/java/transform/ImpressionProcessor.java
@@ -1,0 +1,90 @@
+package transform;
+
+import org.jeasy.batch.core.processor.RecordProcessor;
+import org.jeasy.batch.core.record.GenericRecord;
+import org.jeasy.batch.core.record.Record;
+import org.tensorflow.example.BytesList;
+import org.tensorflow.example.Example;
+import org.tensorflow.example.Feature;
+import org.tensorflow.example.Features;
+import org.tensorflow.example.Int64List;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Process {@link ImpressionRow} into serialized TF Example bytes. */
+public class ImpressionProcessor implements RecordProcessor<ImpressionRow, byte[]> {
+
+    @Override
+    public Record<byte[]> processRecord(Record<ImpressionRow> record) {
+        ImpressionRow row = record.getPayload();
+
+        Map<String, Integer> brandCount = new HashMap<>();
+        List<Action> allActions = new ArrayList<>();
+        if (row.recent_clicks != null) {
+            allActions.addAll(row.recent_clicks);
+        }
+        if (row.recent_add_carts != null) {
+            allActions.addAll(row.recent_add_carts);
+        }
+        for (Action a : allActions) {
+            String brand = a.item != null ? a.item.brand_code : null;
+            if (brand != null) {
+                brandCount.merge(brand, 1, Integer::sum);
+            }
+        }
+        Collections.sort(allActions, Comparator.comparing(a -> Instant.parse(a.occurred_at)).reversed());
+        List<Long> actionItemIds = allActions.stream()
+                .map(a -> (long) a.item.item_id)
+                .collect(Collectors.toList());
+
+        List<Long> itemIds = new ArrayList<>();
+        List<Long> orders = new ArrayList<>();
+        List<Long> brandCounts = new ArrayList<>();
+        for (Impression imp : row.impression) {
+            itemIds.add((long) imp.item.item_id);
+            orders.add(imp.is_order ? 1L : 0L);
+            String brand = imp.item.brand_code;
+            brandCounts.add((long) brandCount.getOrDefault(brand, 0));
+        }
+
+        Example example = Example.newBuilder()
+                .setFeatures(Features.newBuilder()
+                        .putFeature("ranking_id", stringFeature(row.ranking_id))
+                        .putFeature("customer_id", int64Feature(row.customer_id))
+                        .putFeature("item_id", int64ListFeature(itemIds))
+                        .putFeature("is_order", int64ListFeature(orders))
+                        .putFeature("brand_interaction_count", int64ListFeature(brandCounts))
+                        .putFeature("actions", int64ListFeature(actionItemIds))
+                        .build())
+                .build();
+
+        return new GenericRecord<>(record.getHeader(), example.toByteArray());
+    }
+
+    private static Feature int64Feature(long value) {
+        return Feature.newBuilder()
+                .setInt64List(Int64List.newBuilder().addValue(value).build())
+                .build();
+    }
+
+    private static Feature int64ListFeature(List<Long> values) {
+        Int64List.Builder builder = Int64List.newBuilder();
+        for (Long v : values) {
+            builder.addValue(v);
+        }
+        return Feature.newBuilder().setInt64List(builder.build()).build();
+    }
+
+    private static Feature stringFeature(String s) {
+        return Feature.newBuilder()
+                .setBytesList(BytesList.newBuilder().addValue(com.google.protobuf.ByteString.copyFromUtf8(s)).build())
+                .build();
+    }
+}

--- a/transformations/src/main/java/transform/ImpressionRow.java
+++ b/transformations/src/main/java/transform/ImpressionRow.java
@@ -1,0 +1,13 @@
+package transform;
+
+import java.util.List;
+
+/** Representation of one row in the impressions dataset. */
+public class ImpressionRow {
+    public String ranking_id;
+    public int customer_id;
+    public List<Impression> impression;
+    public List<Action> recent_clicks;
+    public List<Action> recent_add_carts;
+    public String ranking_at;
+}

--- a/transformations/src/main/java/transform/ImpressionsToTFRecord.java
+++ b/transformations/src/main/java/transform/ImpressionsToTFRecord.java
@@ -1,0 +1,50 @@
+package transform;
+
+import org.jeasy.batch.core.job.Job;
+import org.jeasy.batch.core.job.JobBuilder;
+import org.jeasy.batch.core.job.JobExecutor;
+import org.jeasy.batch.flatfile.FlatFileRecordReader;
+import org.jeasy.batch.extensions.jackson.JacksonRecordMapper;
+import org.jeasy.batch.core.writer.TFRecordRecordWriter;
+
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+
+/** Utility to transform impressions jsonl files to tfrecord format. */
+public class ImpressionsToTFRecord {
+
+    public static void run(String inputRoot, String outputRoot, String start, String end) throws Exception {
+        LocalDate startDate = LocalDate.parse(start);
+        LocalDate endDate = LocalDate.parse(end);
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            Path inDir = Paths.get(inputRoot, "dt=" + date.toString());
+            if (!Files.isDirectory(inDir)) {
+                continue;
+            }
+            Path outDir = Paths.get(outputRoot, "dt=" + date.toString());
+            Files.createDirectories(outDir);
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(inDir, "*.jsonl")) {
+                for (Path file : stream) {
+                    Path out = outDir.resolve(file.getFileName().toString().replace(".jsonl", ".tfrecord"));
+                    runJob(file, out);
+                }
+            }
+        }
+    }
+
+    private static void runJob(Path inputFile, Path outputFile) throws Exception {
+        Job job = new JobBuilder<ImpressionRow, byte[]>()
+                .reader(new FlatFileRecordReader(inputFile))
+                .mapper(new JacksonRecordMapper<>(ImpressionRow.class))
+                .processor(new ImpressionProcessor())
+                .writer(new TFRecordRecordWriter(outputFile))
+                .build();
+
+        JobExecutor executor = new JobExecutor();
+        executor.execute(job);
+        executor.shutdown();
+    }
+}

--- a/transformations/src/main/java/transform/Item.java
+++ b/transformations/src/main/java/transform/Item.java
@@ -1,0 +1,7 @@
+package transform;
+
+/** Item representation. */
+public class Item {
+    public int item_id;
+    public String brand_code;
+}

--- a/transformations/src/main/java/transform/Main.java
+++ b/transformations/src/main/java/transform/Main.java
@@ -1,0 +1,42 @@
+package transform;
+
+/**
+* Main entry-point for the impressions → TFRecord batch transformation.
+*
+* <p>Expected arguments, in order:
+* <ol>
+*   <li><b>inputPath</b>  – absolute path to the root of the raw JSONL tree</li>
+*   <li><b>outputPath</b> – absolute path where TFRecords will be written</li>
+*   <li><b>startDate</b>  – inclusive start date, format {@code YYYY-MM-DD}</li>
+*   <li><b>endDate</b>    – inclusive end date,   format {@code YYYY-MM-DD}</li>
+* </ol>
+* */
+public class Main {
+
+
+   public static void main(String[] args) {
+       if (args.length != 4) {
+           System.err.printf(
+               "Expected 4 arguments but got %d%n%n" +
+               "Usage: java -jar transformations.jar <inputPath> <outputPath> <startDate> <endDate>%n",
+               args.length
+           );
+           System.exit(1);
+           return;
+       }
+
+
+       String inputPath  = args[0];
+       String outputPath = args[1];
+       String startDate  = args[2];
+       String endDate    = args[3];
+
+
+       try {
+           ImpressionsToTFRecord.run(inputPath, outputPath, startDate, endDate);
+       } catch (Exception e) {
+           e.printStackTrace(System.err);
+           System.exit(2);
+       }
+   }
+}


### PR DESCRIPTION
## Summary
- support writing to TFRecord format in easy-batch-core
- create transformation module for converting impressions JSONL to TFRecords
- include example Main entry point and processor logic

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_688a4a91e078832ab29aadd08f2b5e1f